### PR TITLE
update selects before first render [issue #32]

### DIFF
--- a/pages/covid-visualization/vis.js
+++ b/pages/covid-visualization/vis.js
@@ -187,10 +187,8 @@ var prep_data = function(chart) {
 
   // ensure highlighted country shows when new page load with cookie
   if (_intial_load && countries.indexOf(chart.highlight) == -1) {
-    chart.show = 9999;
     caseData = chart.fullData;
     countries = _.map(caseData, 'country').sort();
-    $("#filter-" + chart.id).val(9999);
   }
 
   var $highlight = $("#highlight-" + chart.id);

--- a/pages/covid-visualization/vis.js
+++ b/pages/covid-visualization/vis.js
@@ -107,6 +107,7 @@ var charts = {
     dataSelection_y0: { 'active': 100, 'cases': 100, 'deaths': 10, 'recovered': 100, 'new-cases': 1 },
     yAxisScale: 'fixed',
     xMax: null, yMax: null, data: null,
+    init: false,
     trendline: "default"
   },
   'states': {
@@ -123,6 +124,7 @@ var charts = {
     dataSelection_y0: { 'active': 20, 'cases': 20, 'deaths': 5, 'recovered': 20 },
     yAxisScale: 'fixed',
     xMax: null, yMax: null, data: null,
+    init: false,
     trendline: "default"
   },
 
@@ -140,6 +142,7 @@ var charts = {
     dataSelection_y0: { 'active': 1, 'cases': 1, 'deaths': 1, 'recovered': 1 },
     yAxisScale: 'fixed',
     xMax: null, yMax: null, data: null,
+    init: false,
     trendline: "default"
   },
   'states-normalized': {
@@ -156,6 +159,7 @@ var charts = {
     dataSelection_y0: { 'active': 1, 'cases': 1, 'deaths': 1, 'recovered': 1 },
     yAxisScale: 'fixed',
     xMax: null, yMax: null, data: null,
+    init: false,
     trendline: "default"
   },
 };
@@ -337,10 +341,15 @@ var populationData_promise = d3.csv("wikipedia-population.csv", function (row) {
 
 var _dataReady = false, _pageReady = false;
 
+var init_selects = function (chart) {
+  $('#' + chart.id).next('div.chart-footer').find('select').each(function () {$(this).change()});
+  chart.init = true;
+}
 
 var tryRender = function () {
   if (_dataReady && _pageReady) {
     process_data(_rawData, charts["countries"]);
+    init_selects(charts["countries"]);
     render(charts["countries"]);
     setTimeout(initialRender2, 100);
   }
@@ -348,12 +357,15 @@ var tryRender = function () {
 
 var initialRender2 = function() {
   process_data(_rawData, charts["states"]);
+  init_selects(charts["states"]);
   render(charts["states"]);
   
   process_data(_rawData, charts["countries-normalized"]);
+  init_selects(charts["countries-normalized"]);
   render(charts["countries-normalized"]);
 
   process_data(_rawData, charts["states-normalized"]);
+  init_selects(charts["states-normalized"]);
   render(charts["states-normalized"]);
 
   _intial_load = false;
@@ -506,7 +518,11 @@ var tip_html = function(chart) {
   }
 };
 
+
 var render = function(chart) {
+  if (!chart.init){
+    return;
+  }
   data_y0 = chart.y0;
   gData = undefined;
   var f = _.find(chart.data, function (e) { return e.country == chart.highlight })


### PR DESCRIPTION
When the visualization page is refreshed the select options can get out of sync with the charts

This PR fixes this issue to make sure that the current select options are respected.

I have tried to make as little change as possible.

There is logic in the `change` event for the selects and then they perform a render.  this PR introduces the `init_selects(chart)` function that finds all selects and calls their `change()` so that the value is reflected using whatever logic the selects change function has.  But this would cause the chart to render.  to prevent this I have added a new chart attribute `init` to show if the chart has been initiated.  If this is `false` the render call does nothing.

The second commit stops the Show filter being reset